### PR TITLE
Add ca-certificate & use local image

### DIFF
--- a/docker-fakece/Dockerfile
+++ b/docker-fakece/Dockerfile
@@ -4,4 +4,4 @@ ADD /transfused /usr/bin/
 ADD /entrypoint.sh /usr/bin/
 RUN mkdir -p /run/config/filesharing
 RUN echo -n osxfs > /run/config/filesharing/mode
-RUN apk --update add fuse
+RUN apk --update add fuse ca-certificates && rm -rf /var/cache/apk/*

--- a/linuxkit/docker-for-mac-wifi.yml
+++ b/linuxkit/docker-for-mac-wifi.yml
@@ -115,7 +115,7 @@ services:
     runtime:
       mkdir: ["/var/lib/docker"]
   - name: docker-fakece
-    image: singelet/docker-fakece:1.0
+    image: docker-fakece:1.0
     capabilities:
         - CAP_SYS_ADMIN
     binds:


### PR DESCRIPTION
singelet/docker-facece does no exists so we have to use local image

Fix for alpine image in Dockerfile using ca-certificate corrects this error: FATA[0016] Error writing outputs: Error writing iso-efi output: docker pull linuxkit/mkimage-iso-efi:1cebc76eab89254f3e288526890bbc7cddf0ffaf failed: exit status 1 output

Signed-off-by: binkybear <binkybear@nehunter.com>